### PR TITLE
Stack trace cache thread safety

### DIFF
--- a/src/rmem_hook.h
+++ b/src/rmem_hook.h
@@ -103,7 +103,10 @@ namespace rmem {
 			void addStackTrace_new(uint8_t* _tmpBuffer, size_t& _tmpBuffPtr, uintptr_t* _stackTrace, uint32_t _numFrames);
 
 			/// Called on each memory operation
-			void addStackTrace(uint8_t* _tmpBuffer, size_t& _tmpBuffPtr);
+			uint32_t addStackTrace(uint8_t* _tmpBuffer, size_t& _tmpBuffPtr);
+
+			/// Called after the stack trace has been written
+			void finalizeStackTrace(const uint32_t stackHash);
 		
 			/// Writes data to the internal buffer
 			void writeToBuffer(void* _ptr, size_t _size, bool _memoryOperation = false);


### PR DESCRIPTION
addStackTrace now adds information to the stack cache but does not set
the hash entry, instead it puts a placeholder value in its place. Once
the data has been written to the output stream the finalizeStackTrace
method is called which stores the correct hash value.